### PR TITLE
Resolution correction

### DIFF
--- a/ps2/src/dragon.cpp
+++ b/ps2/src/dragon.cpp
@@ -86,9 +86,9 @@ int main(){
 	zbuffer_t z;
 	framebuffer_t  framebuffers[2];
 	framebuffers[0].width = 640;
-	framebuffers[0].height = 512;
+	framebuffers[0].height = 448;
 	framebuffers[1].width = 640;
-	framebuffers[1].height = 512;
+	framebuffers[1].height = 448;
 	
 	
 	setupContext(framebuffers, z);


### PR DESCRIPTION
640x512 is standard 50Hz PAL resolution however the demo appears to be running at 60Hz (480i) - I have corrected the resolution to be 640x448 as per standard 60Hz PS2 games (not 640x480, 640x448 for overscan compensation). This may free up a little more VRAM (40,000 less pixels after all) and probably yield marginally better performance?